### PR TITLE
Changes in attributes (typos and availability)

### DIFF
--- a/custom_components/binary_sensor/zha_new.py
+++ b/custom_components/binary_sensor/zha_new.py
@@ -245,7 +245,7 @@ class OccupancySensor(BinarySensor):
             self._state = value
             self.invalidate_after = dt_util.utcnow() + datetime.timedelta(
                 seconds=self.re_arm_sec)
-            self._device_state_attributes['last detection:'] \
+            self._device_state_attributes['last detection'] \
                 = self.invalidate_after
             async_track_point_in_time(
                 self.hass, _async_clear_state(self),
@@ -312,8 +312,8 @@ class Basic(Cluster_Server):
         self._entity.hass.bus.fire('click', event_data)
         _LOGGER.debug('click event [tsn:%s] %s', tsn, event_data)
         self._entity._device_state_attributes.update({
-                'Last seen': dt_util.now(),
-                'Last command': command
+                'last seen': dt_util.now(),
+                'last command': command
         })
         self._entity.schedule_update_ha_state()
 
@@ -396,9 +396,9 @@ class Server_LevelControl(Cluster_Server):
         self._entity.hass.bus.fire('click', event_data)
         _LOGGER.debug('click event [tsn:%s] %s', tsn, event_data)
         self._entity._device_state_attributes.update({
-                'Last seen': dt_util.now(),
+                'last seen': dt_util.now(),
                 self._identifier: self.value,
-                'Last command': command
+                'last command': command
         })
         self._entity.schedule_update_ha_state()
 
@@ -424,9 +424,9 @@ class Server_OnOff(Cluster_Server):
         self._entity.hass.bus.fire('click', event_data)
         _LOGGER.debug('click event [tsn:%s] %s', tsn, event_data)
         self._entity._device_state_attributes.update({
-                'Last seen': dt_util.now(),
+                'last seen': dt_util.now(),
                 self._identifier: self._value,
-                'Last command': command
+                'last command': command
         })
         self._entity.schedule_update_ha_state()
 
@@ -447,9 +447,9 @@ class Server_Scenes(Cluster_Server):
         self._entity.hass.bus.fire('click', event_data)
         _LOGGER.debug('click event [tsn:%s] %s', tsn, event_data)
         self._entity._device_state_attributes.update({
-                'Last seen': dt_util.now(),
+                'last seen': dt_util.now(),
                 self._identifier: args,
-                'Last command': command
+                'last command': command
         })
         self._entity.schedule_update_ha_state()
 
@@ -480,9 +480,9 @@ class RemoteSensor(BinarySensor):
 
     def cluster_command(self, tsn, command_id, args):
         update_attrib = {}
-        update_attrib['Last seen'] = dt_util.now()
+        update_attrib['last seen'] = dt_util.now()
         self._entity._device_state_attributes.update({
-                'Last seen': dt_util.now(),
+                'last seen': dt_util.now(),
                 self._identifier: self.value,
                 'channels': list(c.identifier for c in self.sub_listener_out.items())
         })

--- a/custom_components/sensor/zha_new.py
+++ b/custom_components/sensor/zha_new.py
@@ -173,7 +173,7 @@ class PressureSensor(Sensor):
     @property
     def unit_of_measurement(self):
         """Return the unit of measuremnt of this entity."""
-        return "mbar"
+        return "hPa"
 
     @property
     def state(self):
@@ -193,7 +193,7 @@ class IlluminanceSensor(Sensor):
     @property
     def unit_of_measurement(self):
         """Return the unit of measuremnt of this entity."""
-        return "lux"
+        return "lx"
 
     @property
     def state(self):

--- a/custom_components/zha_new.py
+++ b/custom_components/zha_new.py
@@ -696,6 +696,7 @@ class Entity(entity.Entity):
         self._state = None
         self._device_state_attributes['lqi'] = endpoint.device.lqi
         self._device_state_attributes['rssi'] = endpoint.device.rssi
+        self._device_state_attributes['Last seen'] = None
         _LOGGER.debug("dir entity:%s",  dir(self))
 
     @property


### PR DESCRIPTION
- Atmospheric pressure measures force per unit area, with SI units of Pascals rather than Bars.
- The light sensor unit lux has been replaced with lx when HASS released version 0.69.0 (https://github.com/home-assistant/home-assistant/releases/tag/0.69.0). Change for consistency.
- "Last seen" attribute is not available just after reboot hass. It makes harder to create some sensor templates rely on it. Add None (Null) value.
- Some of attributes last written in Capital "Last seen", but some not, like "last detected"
- "Last detected:" attribute has ":" at the end