### PR TITLE
Fix config_report slicing

### DIFF
--- a/custom_components/zha_new.py
+++ b/custom_components/zha_new.py
@@ -481,7 +481,7 @@ class ApplicationListener:
             # then create cluster if needed and setup reporting
             if join and CONF_CONFIG_REPORT in node_config:
                 for report in node_config.get(CONF_CONFIG_REPORT):
-                    report_cls, report_attr, report_min, report_max, report_change = report[0:4]
+                    report_cls, report_attr, report_min, report_max, report_change = report[0:5]
                     mfgCode = None if not report[5:] else  report[5]
                     if report_cls in endpoint.in_clusters:
                         cluster = endpoint.in_clusters[report_cls]


### PR DESCRIPTION
Python slicing is non inclusive for last index. Joining devices with config_report set would break join with too few arguments.